### PR TITLE
Fix release to include jar file

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -156,7 +156,7 @@ jobs:
           tag_name: liquibase-vertica-${{ needs.setup.outputs.extensionVersion }}
           draft: true
           body: Support for Liquibase ${{ needs.setup.outputs.liquibaseVersion }}.
-          files: liquibase-vertica-*.jar
+          files: liquibase-vertica*.jar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Jar file is named liquibase-verticaDatabase-version.jar instead of liquibase-vertica-version.jar