### PR TITLE
Fixed XSD Logic

### DIFF
--- a/src/main/java/liquibase/ext/vertica/change/CreateProjectionChange.java
+++ b/src/main/java/liquibase/ext/vertica/change/CreateProjectionChange.java
@@ -2,7 +2,7 @@ package liquibase.ext.vertica.change;
 
 import liquibase.change.*;
 import liquibase.database.Database;
-import liquibase.ext.vertica.customlogic.CustomLogicNamespaceDetails;
+import liquibase.ext.vertica.customlogic.VerticaNamespaceDetails;
 import liquibase.ext.vertica.database.VerticaDatabase;
 import liquibase.ext.vertica.statement.CreateProjectionStatement;
 import liquibase.ext.vertica.structure.GroupedColumns;
@@ -252,7 +252,7 @@ public class CreateProjectionChange extends AbstractChange implements ChangeWith
     }
 
     public String getSerializedObjectNamespace() {
-        return CustomLogicNamespaceDetails.CUSTOM_LOGIC_NAMESPACE;
+        return VerticaNamespaceDetails.VERTICA_NAMESPACE;
 
     }
 

--- a/src/main/java/liquibase/ext/vertica/customlogic/VerticaNamespaceDetails.java
+++ b/src/main/java/liquibase/ext/vertica/customlogic/VerticaNamespaceDetails.java
@@ -10,10 +10,11 @@ import liquibase.serializer.core.xml.XMLChangeLogSerializer;
  * Created by vesterma on 03/03/14.
  */
 
-public class CustomLogicNamespaceDetails implements NamespaceDetails {
+public class VerticaNamespaceDetails implements NamespaceDetails {
 
-    public static final String CUSTOM_LOGIC_NAMESPACE = "http://www.liquibase.org/xml/ns/dbchangelog-ext";
-    public static final String CUSTOM_LOGIC_XSD = "../liquibase/ext/vertica/xml/dbchangelog-ext.xsd";
+    public static final String VERTICA_NAMESPACE = "http://www.liquibase.org/xml/ns/dbchangelog-ext/vertica";
+
+    public static final String VERTICA_XSD = VERTICA_NAMESPACE + ".xsd";
 
     @Override
     public int getPriority() {
@@ -37,31 +38,23 @@ public class CustomLogicNamespaceDetails implements NamespaceDetails {
     }
 
     private boolean namespaceCorrect(String namespace) {
-        return namespace.equals(CUSTOM_LOGIC_NAMESPACE) || namespace.equals(CUSTOM_LOGIC_XSD);
+        return namespace.equals(VERTICA_NAMESPACE) || namespace.equals(VERTICA_XSD);
     }
 
     @Override
     public String getShortName(String namespace) {
-        return "vert";
+        return "vertica";
     }
 
     @Override
     public String getSchemaUrl(String namespace) {
-        return CUSTOM_LOGIC_XSD;
+        return VERTICA_XSD;
     }
 
     @Override
     public String[] getNamespaces() {
-//        return new String[0];
-        String[] namespaces = {"vert"};
-        return namespaces;
+        return new String[]{
+                VERTICA_NAMESPACE
+        };
     }
-
-
-    @Override
-    public String getLocalPath(String namespace) {
-        return "xml/dbchangelog-ext.xsd";
-
-    }
-
 }

--- a/src/main/resources/META-INF/services/liquibase.parser.NamespaceDetails
+++ b/src/main/resources/META-INF/services/liquibase.parser.NamespaceDetails
@@ -1,0 +1,1 @@
+liquibase.ext.vertica.customlogic.VerticaNamespaceDetails

--- a/src/main/resources/www.liquibase.org/xml/ns/dbchangelog-ext/vertica.xsd
+++ b/src/main/resources/www.liquibase.org/xml/ns/dbchangelog-ext/vertica.xsd
@@ -1,8 +1,8 @@
 <?xml version="1.1" encoding="UTF-8"?>
 
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" version="1.1"
-            targetNamespace="http://www.liquibase.org/xml/ns/dbchangelog-ext/vert"
-            xmlns="http://www.liquibase.org/xml/ns/dbchangelog-ext/vert"
+            targetNamespace="http://www.liquibase.org/xml/ns/dbchangelog-ext/vertica"
+            xmlns="http://www.liquibase.org/xml/ns/dbchangelog-ext/vertica"
             elementFormDefault="qualified" >
 
     <xsd:import namespace="http://www.liquibase.org/xml/ns/dbchangelog"/>


### PR DESCRIPTION
## Description

The current xsd handling did not correctly work, especially with the changed core logic around more securely parsing XML.

The following XSD definition now works:

```
<?xml version="1.1" encoding="UTF-8" standalone="no"?>
<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                   xmlns:vertica="http://www.liquibase.org/xml/ns/dbchangelog-ext/vertica"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-next.xsd
                    http://www.liquibase.org/xml/ns/dbchangelog-ext/vertica http://www.liquibase.org/xml/ns/dbchangelog-ext/vertica.xsd">

    <changeSet author="example" id="2">
        <vertica:createProjection nodes="ALL NODES" orderby="id" projectionName="t7_super" schemaName="bla" segmentedby="hash(t7.id)" subquery="Select * from bla.t7" ksafe="">
            <vertica:columnv encoding="AUTO" name="id" type="INT"/>
            <vertica:columnv encoding="AUTO" name="i1" type="INT"/>
            <vertica:columnv encoding="AUTO" name="i2" type="INT"/>
        </vertica:createProjection>
    </changeSet>
</databaseChangeLog>
```