### PR TITLE
fix: add missing replaces method for Snapshot Generator

### DIFF
--- a/src/main/java/liquibase/ext/vertica/snapshot/ColumnVerticaSnapshotGenerator.java
+++ b/src/main/java/liquibase/ext/vertica/snapshot/ColumnVerticaSnapshotGenerator.java
@@ -15,6 +15,8 @@ import liquibase.logging.LogFactory;
 import liquibase.snapshot.CachedRow;
 import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.InvalidExampleException;
+import liquibase.snapshot.SnapshotGenerator;
+import liquibase.snapshot.jvm.ColumnSnapshotGenerator;
 import liquibase.snapshot.jvm.JdbcSnapshotGenerator;
 import liquibase.statement.DatabaseFunction;
 import liquibase.structure.DatabaseObject;
@@ -481,9 +483,8 @@ public class ColumnVerticaSnapshotGenerator extends JdbcSnapshotGenerator { //ex
         return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
     }
 
-    /*@Override
+    @Override
     public Class<? extends SnapshotGenerator>[] replaces(){
         return new Class[]{ColumnSnapshotGenerator.class};
-    }*/
-
+    }
 }

--- a/src/main/java/liquibase/ext/vertica/snapshot/UniqueConstraintSnapshotGeneratorVertica.java
+++ b/src/main/java/liquibase/ext/vertica/snapshot/UniqueConstraintSnapshotGeneratorVertica.java
@@ -5,6 +5,7 @@ import liquibase.exception.DatabaseException;
 import liquibase.ext.vertica.database.VerticaDatabase;
 import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.InvalidExampleException;
+import liquibase.snapshot.SnapshotGenerator;
 import liquibase.snapshot.jvm.UniqueConstraintSnapshotGenerator;
 import liquibase.structure.DatabaseObject;
 
@@ -25,13 +26,15 @@ public class UniqueConstraintSnapshotGeneratorVertica extends UniqueConstraintSn
 
     @Override
     protected DatabaseObject snapshotObject(DatabaseObject example, DatabaseSnapshot snapshot) throws DatabaseException {
-        System.out.println("in snapshot");
         return null;
     }
 
     @Override
     protected void addTo(DatabaseObject foundObject, DatabaseSnapshot snapshot) throws DatabaseException {
-        System.out.println("in addTo");
+    }
 
+    @Override
+    public Class<? extends SnapshotGenerator>[] replaces() {
+        return new Class[]{UniqueConstraintSnapshotGenerator.class};
     }
 }


### PR DESCRIPTION
liquibase/liquibase#5775 was merged and fixed a bug where some snapshot generators were not being called. But it also highlighted one issue at least in one OSS extension: if then extension replaces a core generator but is not implementing the replaces method, both generators may be invoked now.